### PR TITLE
Corrects some coords that were strings

### DIFF
--- a/Source/data/MapData-Aliens.js
+++ b/Source/data/MapData-Aliens.js
@@ -119,7 +119,7 @@ var canonnEd3d_guardians = {
                 var poiSite = {};
                 poiSite['cat'] = [401];
                 poiSite['name'] = site.system;
-                poiSite["coords"] = { x: site.x, y: site.y, z: site.z }
+                poiSite["coords"] = { x: parseFloat(site.x), y: parseFloat(site.y), z: parseFloat(site.z) }
                 poiSite["infos"] = "Ancient Ruin<br>"
                 canonnEd3d_guardians.systemsData.systems.push(poiSite);
             }

--- a/Source/data/MapData-GR.js
+++ b/Source/data/MapData-GR.js
@@ -199,7 +199,7 @@ var canonnEd3d_gr = {
 				var poiSite = {};
 				poiSite['cat'] = [214];
 				poiSite['name'] = site.system;
-				poiSite["coords"] = { x: site.x, y: site.y, z: site.z }
+				poiSite["coords"] = { x: parseFloat(site.x), y: parseFloat(site.y), z: parseFloat(site.z) }
 				poiSite["infos"] = "Ancient Ruin<br>"
 				canonnEd3d_gr.systemsData.systems.push(poiSite);
 			}

--- a/Source/data/MapData-Guardians.js
+++ b/Source/data/MapData-Guardians.js
@@ -222,7 +222,7 @@ var canonnEd3d_guardians = {
 				var poiSite = {};
 				poiSite['cat'] = [404];
 				poiSite['name'] = site.system;
-				poiSite["coords"] = { x: site.x, y: site.y, z: site.z }
+				poiSite["coords"] = { x: parseFloat(site.x), y: parseFloat(site.y), z: parseFloat(site.z) }
 				poiSite["infos"] = "Ancient Ruin<br>"
 				canonnEd3d_guardians.systemsData.systems.push(poiSite);
 			}


### PR DESCRIPTION
Unknown ruins pulled in through the cloud data were having coords set as strings in stead of floats which caused recenterViewport to concatenate those values with the result of some math, resulting in an incorrect, direct top down, very zoomed view. This can be observed by loading up the guardian combo map and searching for something like 'Col 173 Sector DY-G b40-4' (by pasting complete into search bar).

This only affects maps where search is available but I believed the other places I corrected should probably be not be strings either, for consistency sake.