### PR TITLE
Changes Lagrange Cloud link to codex map

### DIFF
--- a/Source/include/nav.html
+++ b/Source/include/nav.html
@@ -68,7 +68,7 @@
 					<a href="gen-data.html">Generation Ships</a>
 				</li>
 				<li>
-					<a href="cloud_data.html">Lagrange Clouds</a>
+					<a href="codex.html?hud_category=Cloud">Lagrange Clouds</a>
 				</li>
 				<li>
 					<a href="permit-data.html">Permit Locked Regions</a>


### PR DESCRIPTION
The current Lagrange Cloud link leads to a map that uses the get_cloud_data endpoint which times out trying to return a response due to cloud functions server side constraints (returning too much data or using too many queries). To maintain functionality this change uses the already existing codex map with ?hud_category=Cloud query string which presents similar data (I'm not completely sure of this since the cloud_data page will not load, but it does fit the category and selection)